### PR TITLE
Task-49792 : Remove cyclic dependency with kernel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.exoplatform.kernel</groupId>
-        <artifactId>exo.kernel.commons</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-tomcat</artifactId>
         <version>${project.version}</version>

--- a/tomcat/src/main/java/org/gatein/wci/tomcat/TomcatContainerServlet.java
+++ b/tomcat/src/main/java/org/gatein/wci/tomcat/TomcatContainerServlet.java
@@ -26,9 +26,8 @@ import org.apache.catalina.Container;
 import org.apache.catalina.ContainerServlet;
 import org.apache.catalina.Engine;
 import org.apache.catalina.Wrapper;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
-
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 
@@ -38,7 +37,7 @@ import javax.servlet.http.HttpServlet;
  */
 public class TomcatContainerServlet extends HttpServlet implements ContainerServlet
 {
-  private static final Log              log                      = ExoLogger.getLogger(TomcatContainerServlet.class);
+  private static final Logger           log                      = LoggerFactory.getLogger(TomcatContainerServlet.class);
 
    /** Servlet context init parameter name that can be used to turn off cross-context logout */
    private static final String CROSS_CONTEXT_LOGOUT_KEY = "org.gatein.wci.cross_context_logout";

--- a/tomcat/src/main/java/org/gatein/wci/tomcat/TomcatServletContainerContext.java
+++ b/tomcat/src/main/java/org/gatein/wci/tomcat/TomcatServletContainerContext.java
@@ -33,8 +33,8 @@ import org.apache.catalina.LifecycleEvent;
 import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.LifecycleState;
 import org.apache.catalina.core.StandardContext;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.gatein.wci.RequestDispatchCallback;
 import org.gatein.wci.ServletContainer;
 import org.gatein.wci.ServletContainerFactory;
@@ -65,7 +65,8 @@ import java.util.Set;
  */
 public class TomcatServletContainerContext implements ServletContainerContext, ContainerListener, LifecycleListener
 {
-  private final static Log                     log                     = ExoLogger.getLogger(TomcatServletContainerContext.class);
+  private final static Logger                  log                     =
+                                                   LoggerFactory.getLogger(TomcatServletContainerContext.class);
 
    private static TomcatServletContainerContext instance;
 

--- a/wci/pom.xml
+++ b/wci/pom.xml
@@ -32,8 +32,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.kernel</groupId>
-      <artifactId>exo.kernel.commons</artifactId>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/wci/src/main/java/org/gatein/wci/ServletContainer.java
+++ b/wci/src/main/java/org/gatein/wci/ServletContainer.java
@@ -37,8 +37,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
 import org.gatein.wci.api.GateInServlet;
 import org.gatein.wci.authentication.AuthenticationEvent;
 import org.gatein.wci.authentication.AuthenticationEventType;
@@ -48,6 +46,8 @@ import org.gatein.wci.command.CommandDispatcher;
 import org.gatein.wci.security.Credentials;
 import org.gatein.wci.spi.ServletContainerContext;
 import org.gatein.wci.spi.WebAppContext;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * A static registry for the servlet container context.
@@ -58,10 +58,9 @@ import org.gatein.wci.spi.WebAppContext;
 public final class ServletContainer
 {
 
-  private final static Log                   log                     = ExoLogger.getLogger(ServletContainer.class);
-
+  private static final Logger                log                     = LoggerFactory.getLogger(ServletContainer.class);
    /** . */
-   private final Object lock = new Object();
+   private final Object                      lock                    = new Object();
 
    /** The event webapp listeners. */
    private final Vector<WebAppListener> webAppListeners = new Vector<WebAppListener>();

--- a/wci/src/main/java/org/gatein/wci/spi/CatalinaWebAppContext.java
+++ b/wci/src/main/java/org/gatein/wci/spi/CatalinaWebAppContext.java
@@ -16,8 +16,8 @@
  */
 package org.gatein.wci.spi;
 
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.gatein.wci.command.CommandServlet;
 
 import javax.naming.InitialContext;
@@ -31,7 +31,7 @@ import java.io.InputStream;
  * @author <a href="http://community.jboss.org/people/kenfinni">Ken Finnigan</a>
  */
 public abstract class CatalinaWebAppContext implements WebAppContext {
-  protected final static Log    log                            = ExoLogger.getLogger(CatalinaWebAppContext.class);
+  protected static final Logger log                            = LoggerFactory.getLogger(CatalinaWebAppContext.class);
 
     protected static final String GATEIN_SERVLET_NAME = "TomcatGateInServlet";
     protected static final String GATEIN_SERVLET_PATH = "/tomcatgateinservlet";


### PR DESCRIPTION
Before this fix, there was a dependency on kernel module to use ExoLogger
This fix remove the dependency and use classic slf4j api LoggerFactory.getLogger, with create a logback logger